### PR TITLE
Adding a box which provides 'libvirt'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "velocity42/xenial64"
+  config.vm.box = "generic/ubuntu1710"
   config.vm.provision "shell", :path => "provision.sh", privileged: false
 end


### PR DESCRIPTION
The original box runs only on 'vmware_desktop' or 'virtualbox'.
This box includes also 'libvirt.'